### PR TITLE
fix compiling errors

### DIFF
--- a/cfs/apps/kit_sch/fsw/src/msgtbl.c
+++ b/cfs/apps/kit_sch/fsw/src/msgtbl.c
@@ -120,7 +120,7 @@ bool MSGTBL_LoadCmd(TBLMGR_Tbl *Tbl, uint8 LoadType, const char* Filename)
    int obj, msg;
    
    CFE_EVS_SendEvent(KIT_SCH_INIT_DEBUG_EID, KIT_SCH_INIT_EVS_TYPE,
-                     "MSGTBL_LoadCmd() Entry. sizeof(MsgTbl->Tbl) = %d\n",sizeof(MsgTbl->Tbl));
+                     "MSGTBL_LoadCmd() Entry. sizeof(MsgTbl->Tbl) = %lu\n",sizeof(MsgTbl->Tbl));
    
    /* 
    ** Reset status, object modified flags, and data. A non-zero BufLim
@@ -317,7 +317,7 @@ bool MSGTBL_DumpCmd(TBLMGR_Tbl *Tbl, uint8 DumpType, const char* Filename)
          if (DataWords > (uint8)(MSGTBL_MAX_MSG_WORDS)) {
             
             CFE_EVS_SendEvent(MSGTBL_DUMP_MSG_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Error creating dump file message entry %d. Message word length %d is greater than max data buffer %d",
+                              "Error creating dump file message entry %d. Message word length %d is greater than max data buffer %lu",
                               i, DataWords, PKTUTIL_PRI_HDR_WORDS);         
          }
          else {

--- a/cfs/apps/kit_sch/fsw/src/scheduler.c
+++ b/cfs/apps/kit_sch/fsw/src/scheduler.c
@@ -403,7 +403,7 @@ bool SCHEDULER_SendMsgEntryCmd(void* ObjDataPtr, const CFE_SB_Buffer_t* SbBufPtr
          CFE_MSG_ValidateChecksum(MsgPtr, &ValidChecksum);
          
          CFE_EVS_SendEvent(SCHEDULER_CMD_SUCCESS_EID, CFE_EVS_EventType_INFORMATION, 
-                           "Msg[%d]=Command(ApId,SeqCnt,Len,FuncCode,ValidChecksum)=>(0x%04X,%d,%d,%d,0x%02X)",
+                           "Msg[%d]=Command(ApId,SeqCnt,Len,FuncCode,ValidChecksum)=>(0x%04X,%d,%lu,%d,0x%02X)",
                            MsgIndex,ApId,SeqCnt,Size,FuncCode,ValidChecksum);
             
          DataBuf = &(Scheduler->MsgTbl.Entry[MsgIndex].Buffer[sizeof(CFE_MSG_CommandHeader_t)/2]);
@@ -416,7 +416,7 @@ bool SCHEDULER_SendMsgEntryCmd(void* ObjDataPtr, const CFE_SB_Buffer_t* SbBufPtr
          CFE_MSG_GetMsgTime(MsgPtr, &Time);
          
          CFE_EVS_SendEvent(SCHEDULER_CMD_SUCCESS_EID, CFE_EVS_EventType_INFORMATION, 
-                           "Msg[%d]=Telemetry(ApId,SeqCnt,Len,Seconds,Subsecs)=>(0x%04X,%d,%d,%d,%d)",
+                           "Msg[%d]=Telemetry(ApId,SeqCnt,Len,Seconds,Subsecs)=>(0x%04X,%d,%lu,%d,%d)",
                            MsgIndex,ApId,SeqCnt,Size,Time.Seconds,Time.Subseconds);
            
          DataBuf = &(Scheduler->MsgTbl.Entry[MsgIndex].Buffer[sizeof(CFE_MSG_TelemetryHeader_t)/2]);

--- a/cfs/apps/kit_sch/fsw/src/schtbl.c
+++ b/cfs/apps/kit_sch/fsw/src/schtbl.c
@@ -122,7 +122,7 @@ bool SCHTBL_LoadCmd(TBLMGR_Tbl *Tbl, uint8 LoadType, const char* Filename)
 
    int entry;
    
-   CFE_EVS_SendEvent(KIT_SCH_INIT_DEBUG_EID, KIT_SCH_INIT_EVS_TYPE, "SCHTBL_LoadCmd() Entry. sizeof(SchTbl->Tbl) = %d\n",sizeof(SchTbl->Tbl));
+   CFE_EVS_SendEvent(KIT_SCH_INIT_DEBUG_EID, KIT_SCH_INIT_EVS_TYPE, "SCHTBL_LoadCmd() Entry. sizeof(SchTbl->Tbl) = %lu\n",sizeof(SchTbl->Tbl));
    
    /* 
    ** Reset status, object modified flags, and data. A valid

--- a/cfs/apps/kit_to/fsw/src/pkttbl.c
+++ b/cfs/apps/kit_to/fsw/src/pkttbl.c
@@ -162,7 +162,7 @@ bool    PKTTBL_LoadCmd(TBLMGR_Tbl *Tbl, uint8 LoadType, const char* Filename)
 
    CFE_MSG_ApId_t ApId;
    
-   CFE_EVS_SendEvent(KIT_TO_INIT_DEBUG_EID, KIT_TO_INIT_EVS_TYPE, "PKTTBL_LoadCmd() Entry. sizeof(PktTbl->Tbl) = %d\n", sizeof(PktTbl->Tbl));
+   CFE_EVS_SendEvent(KIT_TO_INIT_DEBUG_EID, KIT_TO_INIT_EVS_TYPE, "PKTTBL_LoadCmd() Entry. sizeof(PktTbl->Tbl) = %lu\n", sizeof(PktTbl->Tbl));
    
    /* 
    ** Reset status, object modified flags, and data. A non-zero BufLim

--- a/cfs/apps/mipea/src/dma.c
+++ b/cfs/apps/mipea/src/dma.c
@@ -39,6 +39,8 @@ volatile struct dma_channel_register_map *DMAC14 = NULL;
 
 volatile struct dma_register_map *DMA = NULL;
 
+int _mbox_fd;
+
 int dma_map(void)
 {
     // open /dev/vcio which is used in mailbox

--- a/cfs/apps/mipea/src/dma.h
+++ b/cfs/apps/mipea/src/dma.h
@@ -102,7 +102,7 @@ uint32_t dma_virt_to_phy(dma_phy_mem_blk *block, void *addr);
 void dma_alloc_phy_mem(dma_phy_mem_blk *block, unsigned int size);
 void dma_free_phy_mem(dma_phy_mem_blk *block);
 
-int _mbox_fd;
+extern int _mbox_fd;
 
 #ifdef  __cplusplus
 }

--- a/cfs/apps/mipea/src/peripherals.c
+++ b/cfs/apps/mipea/src/peripherals.c
@@ -34,7 +34,7 @@
 
 int peripheral_map(volatile uint32_t **map, uint32_t offset, uint32_t size)
 {
-	printf("osk: peripheral_map() - Peripheral Base 0x%08X, Offset 0x%08X, Size 0x%04X\n", PERIPHERAL_BASE, offset, size);
+	printf("osk: peripheral_map() - Peripheral Base 0x%08lX, Offset 0x%08X, Size 0x%04X\n", PERIPHERAL_BASE, offset, size);
 	if (peripheral_ismapped(*map, size)) {
 		printf("osk: peripheral_map() - Already mapped\n");
 		return 0; // already mapped

--- a/cfs/apps/osk_c_fw/fsw/src/childmgr.c
+++ b/cfs/apps/osk_c_fw/fsw/src/childmgr.c
@@ -264,7 +264,7 @@ bool CHILDMGR_InvokeChildCmd(void* ObjDataPtr, const CFE_SB_Buffer_t*  SbBufPtr)
       }/* End if valid message length */
       else {
          
-         sprintf(EventErrStr, "Error dispatching commmand function %d. Command message length %d exceed max %d",
+         sprintf(EventErrStr, "Error dispatching commmand function %d. Command message length %lu exceed max %lu",
             FuncCode, MsgLen, sizeof(CHILDMGR_CmdQ_Entry));
       
       }

--- a/cfs/apps/osk_c_fw/fsw/src/cmdmgr.c
+++ b/cfs/apps/osk_c_fw/fsw/src/cmdmgr.c
@@ -181,7 +181,7 @@ bool CMDMGR_DispatchFunc(CMDMGR_Class* CmdMgr, const CFE_SB_Buffer_t*  SbBufPtr)
                              ((uint8*)SbBufPtr)[0],((uint8*)SbBufPtr)[1],((uint8*)SbBufPtr)[2],((uint8*)SbBufPtr)[3]);
    if (DBG_CMDMGR) OS_printf("CMDMGR_DispatchFunc(): [4]=0x%X, [5]=0x%X, [6]=0x%X, [7]=0x%X\n",
                              ((uint8*)SbBufPtr)[4],((uint8*)SbBufPtr)[5],((uint8*)SbBufPtr)[6],((uint8*)SbBufPtr)[7]);
-   if (DBG_CMDMGR) OS_printf("CMDMGR_DispatchFunc(): FuncCode %d, DataLen %d\n", FuncCode,UserDataLen);
+   if (DBG_CMDMGR) OS_printf("CMDMGR_DispatchFunc(): FuncCode %d, DataLen %lu\n", FuncCode,UserDataLen);
 
    if (FuncCode < CMDMGR_CMD_FUNC_TOTAL) {
 
@@ -202,7 +202,7 @@ bool CMDMGR_DispatchFunc(CMDMGR_Class* CmdMgr, const CFE_SB_Buffer_t*  SbBufPtr)
       else {
 
          CFE_EVS_SendEvent (CMDMGR_DISPATCH_INVALID_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                            "Invalid command user data length %d, expected %d",
+                            "Invalid command user data length %lu, expected %d",
                             UserDataLen, CmdMgr->Cmd[FuncCode].UserDataLen);
 
       }


### PR DESCRIPTION
Fixed build error, mostly format specifier errors.

Only one is `int _mbox_fd;` caused each `#include "dma.h"` will create an instance of `_mbox_id`